### PR TITLE
WIP: Site Preview Github Action

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,43 @@
+name: Build Preview
+
+on: [ pull_request ]
+
+jobs:
+  preview:
+    name: "Build preview site"
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the pull request under "site/".
+      - name: "Clone pull request"
+        uses: actions/checkout@v2
+        with:
+          path: site
+
+      # Check out the preview site repo under "preview/".
+      # TODO: setup a PAT for this
+      - name: "Clone preview site"
+        uses: actions/checkout@v2
+        with:
+          repository: ocelotconsulting/ocelot.github.io
+          path: preview
+          token: ${{ secrets.PAT }}
+
+      # Create patch file for this pull request.
+      - name: "Create patch file for pull request"
+        shell: bash
+        working-directory: ./site
+        run: git format-patch master --stdout > pr.patch
+
+      # Apply patch file to preview repository.
+      - name: "Apply patch to preview site"
+        shell: bash
+        working-directory: ./preview
+        run: git am $GITHUB_WORKSPACE/site/pr.patch
+
+      # Push to preview repository.
+      # TODO: setup a PAT for this
+      - name: "Push preview site"
+        working-directory: ./preview
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.PAT }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -37,7 +37,7 @@ jobs:
       # Push to preview repository.
       # TODO: setup a PAT for this
       - name: "Push preview site"
-        working-directory: ./preview
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.PAT }}
+          directory: ./preview


### PR DESCRIPTION
Adds a basic Github Action that would take the patch from a new PR on this repository and apply it to the `master` branch of the [preview repository](https://github.com/ocelotconsulting/ocelot.github.io).

I used patches because they're typically easier to deal with when commit histories diverge, but we might be able to do some magic with [`merge --allow-unrelated-histories`](https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---allow-unrelated-histories). Otherwise we could nuke the history of the preview repo on `master` to match that of this repository.

The `local` token (`${{ github.token }}`) that you get for free when an action starts up is scoped **only** to the current repository, so we'd need some other way to perform remote operations on the [preview repository](https://github.com/ocelotconsulting/ocelot.github.io). I set this up to use a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line), but we could also use an SSH key.

I marked this PR as a `WIP` because one of the organization owners would need to set up a PAT in [the secrets for this repository](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) before this would work — I don't have permissions to edit those.