### PR TITLE
Unnecessary horizontal scrolling fix

### DIFF
--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -1,6 +1,6 @@
 #home {
   #nav {
-    margin-top: .75rem;
+    margin-top: 0rem;
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -31,16 +31,6 @@
   padding-top: 5rem;
 }
 
-.columns {
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
-
-  &:not(:last-child) {
-    margin-bottom: 0;
-  }
-}
-
 /* Suggested workaround for Bulma bug that causes horizontal 
    scrolling. See https://github.com/jgthms/bulma/issues/2242 */
 .columns {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -32,7 +32,7 @@
 }
 
 /* Suggested workaround for Bulma bug that causes horizontal 
-   scrolling. See https://github.com/jgthms/bulma/issues/2242 */
+   scrolling. See https://github.com/jgthms/bulma/issues/2242. */
 .columns {
   margin-left: 0;
   margin-right: 0;
@@ -42,7 +42,6 @@
     margin-bottom: 0;
   }
 }
-
 
 /* The following were added to support the old
  * posts. They can be re-thought in the future

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -31,6 +31,29 @@
   padding-top: 5rem;
 }
 
+.columns {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+
+  &:not(:last-child) {
+    margin-bottom: 0;
+  }
+}
+
+/* Suggested workaround for Bulma bug that causes horizontal 
+   scrolling. See https://github.com/jgthms/bulma/issues/2242 */
+.columns {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+
+  &:not(:last-child) {
+    margin-bottom: 0;
+  }
+}
+
+
 /* The following were added to support the old
  * posts. They can be re-thought in the future
  * after we re-style the posts section. */


### PR DESCRIPTION
Bulma, a CSS framework we're using, has a documented issue resulting in unnecessary horizontal scrolling when visiting the site on mobile.

Applied here a suggested workaround to remove the gaps between columns that Bulma applies.

Tested this change on mobile chrome, desktop chrome, desktop safari, and desktop edge.

Fixes #27 