### PR TITLE
Fix header spacing

### DIFF
--- a/_layouts/page_w_header.html
+++ b/_layouts/page_w_header.html
@@ -7,42 +7,44 @@
   <div class='nav-spacer page-contents'>
     <div id="highlights">
       <section class="section grey-gradiant">
-        {% if page.background %}
-        <div class="background {{ page.background }}">
-          <div class="dot-background"></div>
-        </div>
-        {% else %}
-        <div class="background"></div>
-        {% endif %}
-        <div class="container">
-          <div class="content">
-            <div class="columns welcome-text is-hidden-mobile">
-              <div class="column is-6">
-                <ul class="is-size-1">
-                  <li> {{ page.title }}</li>
-                </ul>
+        <div class="{% if page.background %}{{ page.background }}{% else %}background{% endif %}-container">
+          {% if page.background %}
+          <div class="background {{ page.background }}">
+            <div class="dot-background"></div>
+          </div>
+          {% else %}
+          <div class="background"></div>
+          {% endif %}
+          <div class="container">
+            <div class="content">
+              <div class="columns welcome-text is-hidden-mobile">
+                <div class="column is-6">
+                  <ul class="is-size-1">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
+                <div class="column is-5">
+                  <h2 class="subtitle welcome-text__subtitle">
+                    {{ page.subtitle }}
+                  </h2>
+                </div>
               </div>
-              <div class="column is-5">
-                <h2 class="subtitle welcome-text__subtitle">
-                  {{ page.subtitle }}
-                </h2>
-              </div>
-            </div>
-            <div class="columns welcome-text is-hidden-tablet">
-              <div class="column is-5">
-                <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
-                  <li> {{ page.title }}</li>
-                </ul>
+              <div class="columns welcome-text is-hidden-tablet">
+                <div class="column is-5">
+                  <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>
         </div>
         {% if page.customClass %}
-        <div class="container container--padding container--{{ page.customClass }}">
+        <div class="container with-padding container--{{ page.customClass }}">
           {{ content }}
         </div>
         {% else %}
-        <div class="container container--padding">
+        <div class="container with-padding">
           {{ content }}
         </div>
         {% endif %}

--- a/_layouts/page_w_image_subtitle.html
+++ b/_layouts/page_w_image_subtitle.html
@@ -7,35 +7,38 @@
   <div class='nav-spacer page-contents'>
     <div id="highlights">
       <section class="section grey-gradiant">
-        {% if page.background %}
-        <div class="background {{ page.background }}">
-          <div class="dot-background"></div>
-        </div>
-        {% else %}
-        <div class="background">
-          <div class="dot-background"></div>
-        </div>
-        {% endif %}
-        <div class="container">
-          <div class="content">
-            <div class="columns welcome-text is-hidden-mobile">
-              <div class="column is-5">
-                <ul class="is-size-1 welcome-text__small-margin">
-                  <li> {{ page.title }}</li>
-                </ul>
+        <div class="{% if page.background %}{{ page.background }}{% else %}background{% endif %}-container">
+          {% if page.background %}
+          <div class="background {{ page.background }}">
+            <div class="dot-background"></div>
+          </div>
+          {% else %}
+          <div class="background">
+            <div class="dot-background"></div>
+          </div>
+          {% endif %}
+          <div class="container">
+            <div class="content">
+              <div class="columns welcome-text is-hidden-mobile">
+                <div class="column is-5">
+                  <ul class="is-size-1 welcome-text__small-margin">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
+                <div class="column" style="margin-top: {{ page.topMargin }}">
+                  <img src="{{ page.image }}" width="{{ page.imageWidth }}" height="{{ page.imageHeight }}" />
+                </div>
               </div>
-              <div class="column" style="margin-top: {{ page.topMargin }}">
-                <img src="{{ page.image }}" width="{{ page.imageWidth }}" height="{{ page.imageHeight }}" />
-              </div>
-            </div>
-            <div class="columns welcome-text is-hidden-tablet">
-              <div class="column is-5">
-                <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
-                  <li> {{ page.title }}</li>
-                </ul>
+              <div class="columns welcome-text is-hidden-tablet">
+                <div class="column is-5">
+                  <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>
+        </div>
           {{ content }}
       </section>
     </div>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -7,32 +7,34 @@
   <div class='nav-spacer page-contents'>
     <div id="highlights">
       <section class="section grey-gradiant">
-        {% if page.background %}
-        <div class="background {{ page.background }}">
-          <div class="dot-background"></div>
-        </div>
-        {% else %}
-        <div class="background"></div>
-        {% endif %}
-        <div class="container">
-          <div class="content">
-            <div class="columns welcome-text is-hidden-mobile">
-              <div class="column is-6">
-                <ul class="is-size-1">
-                  <li> {{ page.title }}</li>
-                </ul>
+        <div class="{% if page.background %}{{ page.background }}{% else %}background{% endif %}-container">
+          {% if page.background %}
+          <div class="background {{ page.background }}">
+            <div class="dot-background"></div>
+          </div>
+          {% else %}
+          <div class="background"></div>
+          {% endif %}
+          <div class="container">
+            <div class="content">
+              <div class="columns welcome-text is-hidden-mobile">
+                <div class="column is-6">
+                  <ul class="is-size-1">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
+                <div class="column is-5">
+                  <h2 class="subtitle welcome-text__subtitle">
+                    {{ page.subtitle }}
+                  </h2>
+                </div>
               </div>
-              <div class="column is-5">
-                <h2 class="subtitle welcome-text__subtitle">
-                  {{ page.subtitle }}
-                </h2>
-              </div>
-            </div>
-            <div class="columns welcome-text is-hidden-tablet">
-              <div class="column is-5">
-                <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
-                  <li> {{ page.title }}</li>
-                </ul>
+              <div class="columns welcome-text is-hidden-tablet">
+                <div class="column is-5">
+                  <ul style="padding-left: 2rem;" class="is-size-1 has-text-left is-capitalized">
+                    <li> {{ page.title }}</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -52,6 +52,19 @@
       height: 31rem !important;
     }
 
+    /* Container sizes for our background container */
+    .shortBackground-container {
+      min-height: 25rem !important;
+    }
+    
+    .shorterBackground-container {
+      min-height: 28rem !important;
+    }
+
+    .mediumBackground-container {
+      min-height: 31rem !important;
+    }
+
     .container {
       z-index: 2;
       &--padding {

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -55,9 +55,9 @@
     .container {
       z-index: 2;
       &--padding {
-        padding: 12rem 0rem;
+        padding: 11rem 0rem;
         @include mobile {
-          padding: 12rem 1rem;
+          padding: 11rem 1rem;
         }
       }
       .card {
@@ -69,7 +69,7 @@
         color: $grey-light;
         .welcome-text {
           ul {
-            margin: 0.5rem 0 0 ;
+            margin: 1rem 0 0 ;
             list-style: none;
             //min-height: 15rem;
             text-transform: uppercase;
@@ -88,7 +88,7 @@
           animation-fill-mode: backwards;
 
           &__subtitle {
-            margin: 0.5rem 0 0;
+            margin: 1rem 0 0;
             color: white;
           }
         }

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -55,9 +55,9 @@
     .container {
       z-index: 2;
       &--padding {
-        padding: 11rem 0rem;
+        padding: 12rem 0rem;
         @include mobile {
-          padding: 11rem 1rem;
+          padding: 12rem 1rem;
         }
       }
       .card {

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -53,16 +53,17 @@
     }
 
     /* Container sizes for our background container */
+    /* Every page that has the background includes 3.25rem for the nav we remove from the height */
     .shortBackground-container {
-      min-height: 25rem !important;
+      min-height: 22rem !important;
     }
     
     .shorterBackground-container {
-      min-height: 28rem !important;
+      min-height: 25rem !important;
     }
 
     .mediumBackground-container {
-      min-height: 31rem !important;
+      min-height: 28rem !important;
     }
 
     .container {

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -55,7 +55,7 @@
     .container {
       z-index: 2;
       &--padding {
-        padding: 6rem 0rem;
+        padding: 12rem 0rem;
         @include mobile {
           padding: 12rem 1rem;
         }
@@ -69,7 +69,7 @@
         color: $grey-light;
         .welcome-text {
           ul {
-            margin: 6rem 0 0 ;
+            margin: 0.5rem 0 0 ;
             list-style: none;
             //min-height: 15rem;
             text-transform: uppercase;
@@ -88,7 +88,7 @@
           animation-fill-mode: backwards;
 
           &__subtitle {
-            margin: 12rem 0 0;
+            margin: 0.5rem 0 0;
             color: white;
           }
         }

--- a/_sass/_shared.scss
+++ b/_sass/_shared.scss
@@ -29,13 +29,13 @@
     padding-top: 5rem;
   }
   &--with-padding {
-    padding-top: 11rem;
+    padding-top: 12rem;
     padding-bottom: 2rem;
   }
 }
 
 .with-padding {
-  padding-top: 11rem;
+  padding-top: 12rem;
   padding-bottom: 2rem;
 }
 

--- a/_sass/_shared.scss
+++ b/_sass/_shared.scss
@@ -29,13 +29,13 @@
     padding-top: 5rem;
   }
   &--with-padding {
-    padding-top: 7rem;
+    padding-top: 12rem;
     padding-bottom: 2rem;
   }
 }
 
 .with-padding {
-  padding-top: 7rem;
+  padding-top: 12rem;
   padding-bottom: 2rem;
 }
 

--- a/_sass/_shared.scss
+++ b/_sass/_shared.scss
@@ -29,13 +29,13 @@
     padding-top: 5rem;
   }
   &--with-padding {
-    padding-top: 12rem;
+    padding-top: 11rem;
     padding-bottom: 2rem;
   }
 }
 
 .with-padding {
-  padding-top: 12rem;
+  padding-top: 11rem;
   padding-bottom: 2rem;
 }
 

--- a/_sass/_shared.scss
+++ b/_sass/_shared.scss
@@ -29,13 +29,13 @@
     padding-top: 5rem;
   }
   &--with-padding {
-    padding-top: 12rem;
+    padding-top: 1rem;
     padding-bottom: 2rem;
   }
 }
 
 .with-padding {
-  padding-top: 12rem;
+  padding-top: 1rem;
   padding-bottom: 2rem;
 }
 


### PR DESCRIPTION
Shifting the header up to the top, instead of having a large margin from the nav bar, helps with long-running titles. Also, integrating the header background and title/subtitles into a shared `<div>` allows the content div to position itself properly without large padding values.

Some instances still have overflow issues. Primarily when a screen size is between a tablet and desktop (around ~800px), some titles get too long for their spacing unfortunately. Those should be fringe cases.

Also includes a fix for a missing `</div>` element in one of the template files.