### PR TITLE
Fixing List CSS Styles in Posts

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -41,7 +41,7 @@
         </div>
         <div class="container with-padding">
           <div class="columns is-centered is-mobile">
-            <div class="column is-8-desktop is-10-tablet is-11-mobile">
+            <div class="column is-8-desktop is-10-tablet is-11-mobile post-list-fix">
               <p>
                 <i>Posted by {{page.author}} on {{page.date | date: "%b %d, %Y"}}</i>
               </p>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -87,6 +87,59 @@
   }
 }
 
+/* In bulma, lists outside of .content
+ * divs have no margins or padding
+ * Content from bulma/elements/content.sass
+ * and converted to scss
+ */
+
+.post-list-fix {
+  li + li {
+  margin-top: 0.25em;
+  }
+
+  ol,
+  ul {
+    &:not(:last-child) {
+      margin-bottom: 1em;
+    }
+  }
+
+  ol {
+    list-style-position: outside;
+    margin-left: 2em;
+    margin-top: 1em;
+    &:not([type]) {
+      list-style-type: decimal;
+      &.is-lower-alpha {
+        list-style-type: lower-alpha;
+      }
+      &.is-lower-roman {
+        list-style-type: lower-roman;
+      }
+      &.is-upper-alpha {
+        list-style-type: upper-alpha;
+      }
+      &.is-upper-roman {
+        list-style-type: upper-roman;
+      }
+    }
+  }
+
+  ul {
+    list-style: disc outside;
+    margin-left: 2em;
+    margin-top: 1em;
+    ul {
+      list-style-type: circle;
+      margin-top: 0.5em;
+      ul {
+        list-style-type: square;
+      }
+    }
+  }
+}
+
 @import "_animations";
 @import "_common";
 @import "_nav";


### PR DESCRIPTION
Lists get their margins and padding stripped outside of `.content` divs (per Bulma styles). This makes for a very unappealing look. Side by side comparisons below. This change only applies to post content using a `.post-fix-list` class inside the posts template.

![image](https://user-images.githubusercontent.com/5490719/125636893-e921833e-9e47-4f11-9692-f04c37acc98f.png)

![image](https://user-images.githubusercontent.com/5490719/125636908-f519e01f-c56d-416e-b16a-db6cfd07fbae.png)
