### PR TITLE
Updated Gemfile.lock for x86_64 linux (WSL 2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -256,6 +258,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   github-pages


### PR DESCRIPTION
When building on Linux x64, the `Gemfile.lock` entries get modified to include a system specific dependency version. This is simply to include that dependency and remove the changes from local trees that depend on it without using `.gitignore`.

This doesn't actually change any site content.