### PR TITLE
Removed Ocelot Consulting Public Slack

### DIFF
--- a/_includes/contact-us.html
+++ b/_includes/contact-us.html
@@ -114,12 +114,6 @@
             <i class="fas fa-rss"></i>
           </a>
         </span>
-
-        <span class="social-media-container__icon">
-          <a class="button button--rounded-button" href="https://join.slack.com/t/ocelot-consulting-pub/shared_invite/zt-fbfmqoz9-30Ur9KmHYALDm17akmGOng" target="_blank">
-            <i class="fab fa-slack"></i>
-          </a>
-        </span>
       </div>
       {% if page.attribution %}
       <div class="columns">


### PR DESCRIPTION
In the contact us part of the footer, an old icon and link to the public Ocelot Consulting Slack still existed. That Slack was shutdown a few months ago and the link is no longer active. This simply removes the button.