### PR TITLE
Initial Post Body CSS Class Fix

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -41,7 +41,7 @@
         </div>
         <div class="container with-padding">
           <div class="columns is-centered is-mobile">
-            <div class="column is-8-desktop is-10-tablet is-11-mobile post-list-fix">
+            <div class="column is-8-desktop is-10-tablet is-11-mobile">
               <p>
                 <i>Posted by {{page.author}} on {{page.date | date: "%b %d, %Y"}}</i>
               </p>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -45,7 +45,9 @@
               <p>
                 <i>Posted by {{page.author}} on {{page.date | date: "%b %d, %Y"}}</i>
               </p>
-              {{ content }}
+              <div class="content">
+                {{ content }}
+              </div>
               <br/>
               <div class="social-share-btns-container">
                 <div class="social-share-btns">

--- a/_sass/_hightlights.scss
+++ b/_sass/_hightlights.scss
@@ -80,7 +80,6 @@
         }
       }
       .content {
-        color: $grey-light;
         .welcome-text {
           ul {
             margin: 1rem 0 0 ;
@@ -89,6 +88,7 @@
             text-transform: uppercase;
             letter-spacing: 1rem;
             font-size: 3rem;
+            color: $grey-light;
           }
 
           @include mobile {

--- a/_sass/_page-contents.scss
+++ b/_sass/_page-contents.scss
@@ -27,3 +27,12 @@
     }
   }
 }
+
+// Hides the list bullets but keeps the spacing (primarily used in page_w_header.html)
+.content .dashboard-panel ul.menu-list, .content .dashboard-panel ol.menu-list {
+  list-style-type: none;
+
+  li {
+    margin-bottom: 1em;
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -87,59 +87,6 @@
   }
 }
 
-/* In bulma, lists outside of .content
- * divs have no margins or padding
- * Content from bulma/elements/content.sass
- * and converted to scss
- */
-
-.post-list-fix {
-  li + li {
-  margin-top: 0.25em;
-  }
-
-  ol,
-  ul {
-    &:not(:last-child) {
-      margin-bottom: 1em;
-    }
-  }
-
-  ol {
-    list-style-position: outside;
-    margin-left: 2em;
-    margin-top: 1em;
-    &:not([type]) {
-      list-style-type: decimal;
-      &.is-lower-alpha {
-        list-style-type: lower-alpha;
-      }
-      &.is-lower-roman {
-        list-style-type: lower-roman;
-      }
-      &.is-upper-alpha {
-        list-style-type: upper-alpha;
-      }
-      &.is-upper-roman {
-        list-style-type: upper-roman;
-      }
-    }
-  }
-
-  ul {
-    list-style: disc outside;
-    margin-left: 2em;
-    margin-top: 1em;
-    ul {
-      list-style-type: circle;
-      margin-top: 0.5em;
-      ul {
-        list-style-type: square;
-      }
-    }
-  }
-}
-
 @import "_animations";
 @import "_common";
 @import "_nav";


### PR DESCRIPTION
This is an initial fix for #96 where we reinstate the `.content` wrapper around blog posts (`posts.html`). This change required fixing the `_highlights.css` file to only change the `font-color` for the `.welcome-text` classes and not the entire element. It also impacted how the menu on the `/industries/` page loaded where the bullets were showing again. That was removed and extra padding was added to the `li` items to recreate the original spacing look.

The main changes for the blog posts are:

1. Extra whitespace around headers, it's easier to read
2. Removed the `post-list-fix` hack from before

Besides the whitespace, nothing else should be visibly different between the entries. A/B comparisons were done using a local build and tabbing back and forth from the production website.

All primary non-blog pages were tested with no other changes besides the industries menu as mentioned.

This does not complete #96, we should still review the CSS and see if we can't keep Bulma upgraded without breaking the site.