### PR TITLE
Change attributions to be center aligned

### DIFF
--- a/_sass/_contact-us.scss
+++ b/_sass/_contact-us.scss
@@ -7,6 +7,8 @@
 .attribution {
     color: white;
     padding-left: 2rem;
+    text-align: center;
+    font-size: 0.9rem;
 }
 
 .subtitle {


### PR DESCRIPTION
Attributions currently sit left aligned and the default font size. This reduces the font size and centers it to better fit in with the contact us buttons.

Before:  
![image](https://user-images.githubusercontent.com/5490719/135106402-a3047ad6-f9e0-4ff9-9886-6a8710995105.png)

After:  
![image](https://user-images.githubusercontent.com/5490719/135106425-7a4ebe84-9b93-4673-969a-905625215e07.png)

