### PR TITLE
Fixing swiper on case studies page

### DIFF
--- a/src/components/SwiperPrev.tsx
+++ b/src/components/SwiperPrev.tsx
@@ -4,7 +4,7 @@ import {faChevronLeft} from '@fortawesome/free-solid-svg-icons/faChevronLeft'
 
 export default function SwiperPrev() {
     return (
-        <button className="button-next absolute top-1/2 -left-5 z-10 -translate-y-1/2 w-10 h-10 bg-black text-white flex flex-col justify-center items-center">
+        <button className="button-prev absolute top-1/2 -left-5 z-10 -translate-y-1/2 w-10 h-10 bg-black text-white flex flex-col justify-center items-center">
             <FontAwesomeIcon icon={faChevronLeft} />
         </button>
     )

--- a/src/components/index/CaseStudyCarousel.tsx
+++ b/src/components/index/CaseStudyCarousel.tsx
@@ -18,7 +18,9 @@ export default function CaseStudyCarousel({cards}: CaseStudyCarouselProps) {
                 modules={[Navigation]}
                 slidesPerView={1}
                 spaceBetween={20}
-                loop={true}
+                // Doc: Because of nature of how the loop mode works (it will rearrange slides), total number of slides must be >= slidesPerView * 2
+                // Loop only if we meet the highest breakpoint
+                loop={cards.length / 2 >= 5}
                 autoplay={true}
                 breakpoints={{
                     768: {

--- a/src/pages/case-studies/index.tsx
+++ b/src/pages/case-studies/index.tsx
@@ -40,7 +40,9 @@ export default function CaseStudies({caseStudies, setShowContact}: CaseStudiesPr
                     slidesPerView={1}
                     spaceBetween={20}
                     modules={[Navigation]}
-                    loop={true}
+                    // Doc: Because of nature of how the loop mode works (it will rearrange slides), total number of slides must be >= slidesPerView * 2
+                    // Loop only if we meet the highest breakpoint
+                    loop={caseStudies.length / 2 >= 4}
                     autoplay={true}
                     navigation={{
                         nextEl: '.button-next',
@@ -55,8 +57,8 @@ export default function CaseStudies({caseStudies, setShowContact}: CaseStudiesPr
                         }
                     }}
                 >
-                    {caseStudies.map((caseStudy) => (
-                        <SwiperSlide key={caseStudy.slug}>
+                    {caseStudies.map((caseStudy, index) => (
+                        <SwiperSlide key={index}>
                             <CaseStudyCard
                                 level={caseStudy.level}
                                 icon={caseStudy.icon}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -49,6 +49,11 @@ body {
   font-size: 1rem !important;
 }
 
+/* Hide the buttons when disabled */
+.swiper-button-disabled {
+  visibility: hidden;
+}
+
 .hero-slider img {
   transform-origin: center;
   transform: scale(1.05);


### PR DESCRIPTION
Loop only works when we have `>= 2 * slidesPerView` according to the documentation. This code will disable looping when we do not have enough cards to fill it based on the highest `slidesPerView` value.

CSS to hide the disabled buttons included.

Future: Can the loop be enabled/disabled dynamically based on the actual `slidesPerView` value?

Hidden button sample:
![image](https://user-images.githubusercontent.com/5490719/234354809-f547aaf7-821e-408f-8875-6820a77ede3d.png)

Fixes #133 
Fixes #141 
