### PR TITLE
Fixing configure-pages to initialize mjs version of next.config.mjs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
+          generator_config_file: next.config.mjs
       - name: Restore cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
`actions/configure-pages@v3` defaults to `next.config.js` but with the change to `mjs` to support GitHub Flavored Markdown, this broke the releases.