### PR TITLE
Changed to bg-left for background image alignment

### DIFF
--- a/src/pages/services/cloud-transformation.tsx
+++ b/src/pages/services/cloud-transformation.tsx
@@ -69,7 +69,7 @@ export default function CloudTransformation({setShowContact}: any) {
 
             <Section
                 style={{backgroundImage: `url(${ctaBg.src})`}}
-                className="bg-cover bg-center max-lg:!bg-none bg-med-gray"
+                className="bg-cover bg-left max-lg:!bg-none bg-med-gray"
             >
                 <Grid>
                     <div>

--- a/src/pages/services/data-engineering.tsx
+++ b/src/pages/services/data-engineering.tsx
@@ -63,7 +63,7 @@ export default function DataEngineering({setShowContact}: any) {
 
         <Section
             style={{backgroundImage: `url(${ctaBg.src})`}}
-            className="bg-cover bg-center max-lg:!bg-none bg-med-gray"
+            className="bg-cover bg-left max-lg:!bg-none bg-med-gray"
         >
             <Grid>
                 <div>

--- a/src/pages/services/data-science.tsx
+++ b/src/pages/services/data-science.tsx
@@ -65,7 +65,7 @@ export default function DataScience({setShowContact}: any) {
 
         <Section
             style={{backgroundImage: `url(${ctaBg.src})`}}
-            className="bg-cover bg-center max-lg:!bg-none bg-med-gray"
+            className="bg-cover bg-left max-lg:!bg-none bg-med-gray"
         >
             <Grid>
                 <div>

--- a/src/pages/services/full-stack-development.tsx
+++ b/src/pages/services/full-stack-development.tsx
@@ -62,7 +62,7 @@ export default function FullStackDevelopment({setShowContact}: any) {
 
             <Section
                 style={{backgroundImage: `url(${ctaBg.src})`}}
-                className="bg-cover bg-center max-lg:!bg-none bg-med-gray"
+                className="bg-cover bg-left max-lg:!bg-none bg-med-gray"
             >
                 <Grid>
                     <div>

--- a/src/pages/services/strategy-execution.tsx
+++ b/src/pages/services/strategy-execution.tsx
@@ -83,7 +83,7 @@ export default function StrategyAndExecution({setShowContact}: any) {
 
         <Section
             style={{backgroundImage: `url(${ctaBg.src})`}}
-            className="bg-cover bg-center max-lg:!bg-none bg-med-gray"
+            className="bg-cover bg-left max-lg:!bg-none bg-med-gray"
         >
             <Grid>
                 <div>


### PR DESCRIPTION
No feedback was given on not changing the alignment, so I have gone ahead and made the adjustments. The only issue will be screens around 1025-1100px in width that causes some overlapping. See the issue for an example.

Example change from cloud transformation:

Before:
![image](https://github.com/ocelotconsulting/ocelotconsulting.github.io/assets/5490719/cedd301a-4ab6-4c11-a927-280463897e03)

After:
![image](https://github.com/ocelotconsulting/ocelotconsulting.github.io/assets/5490719/1128d316-a739-4dfe-8ad5-63942e80c2ef)

Fixes #155 