### PR TITLE
Reduce animations for easier reading

### DIFF
--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -3,7 +3,8 @@ import {useInView} from 'react-intersection-observer'
 
 export default function FadeIn({className, children, ...props}: ComponentPropsWithoutRef<'div'>) {
     const { ref, inView, entry } = useInView({
-        threshold: 0.5
+        threshold: 0.5,
+        triggerOnce: true
     })
 
     const currentClass = inView ? '' : 'opacity-0'

--- a/src/components/animations/SlideUp.tsx
+++ b/src/components/animations/SlideUp.tsx
@@ -4,7 +4,8 @@ import {useInView} from 'react-intersection-observer'
 
 export default function SlideUp({className, children, ...props}: ComponentPropsWithoutRef<'div'>) {
     const { ref, inView, entry } = useInView({
-        threshold: 0.5
+        threshold: 0.5,
+        triggerOnce: true
     })
 
     const currentClass = inView ? '' : 'opacity-0 translate-y-6'


### PR DESCRIPTION
Enable triggerOnce for animations/transitions so that sections that fade in or slide up only occur once. Currently if you scroll past a section that was animated, it will be removed from view and then re-animated on its next view. Once a section is shown, it shouldn't be re-animated for a better user experience when scrolling.