### PR TITLE
Added OneTrust Cookie Prompts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
         description: The base path to configure for Next.JS (No trailing slash, empty string for root)
         type: string
         default: ''
+      NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT:
+        description: The data-domain-script value to pass for OneTrust cookie handling
+        type: string
+        default: '3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef-test'
   
   workflow_dispatch:
     inputs:
@@ -12,12 +16,17 @@ on:
         description: The base path to configure for Next.JS (No trailing slash, empty string for root)
         type: string
         default: ''
+      NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT:
+        description: The data-domain-script value to pass for OneTrust cookie handling
+        type: string
+        default: '3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef-test'
 
 env:
   NEXT_PUBLIC_ANALYTICS_ID: 6LduFgEVAAAAAJLy0R672PEdTafugaVHktVYcMLD
   NEXT_PUBLIC_CONTACT_FORM_TO: info@ocelotconsulting.com
   NEXT_PUBLIC_CONTACT_FORM_URL: https://9qpcx5jjib.execute-api.us-east-1.amazonaws.com/prod/
   NEXT_PUBLIC_BASEPATH: ${{ inputs.basePath }}
+  NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT: ${{ inputs.NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT }}
 
 jobs:
   # Build job

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
   # Build job
   build:
     uses: ./.github/workflows/build.yml
+    with:
+      NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT: 3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef
 
   deploy:
     # Add a dependency to the build job

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -109,7 +109,7 @@ export default function Footer() {
             <div className="border-t border-dark-gray p-4 text-xs">
                 <div className="container mx-auto flex flex-col lg:flex-row justify-between">
                     <div className="text-center">
-                        &copy; {(new Date()).getFullYear()} Ocelot Consulting, Part of Accenture. All rights reserved. | <a href="https://www.accenture.com/us-en/about/privacy-policy" className="hover:text-accent" target="_blank" title="Privacy Policy">Privacy Policy</a> | <a href="https://www.accenture.com/us-en/support/company-cookies-similar-technology" className="hover:text-accent" target="_blank" title="Privacy Policy">Cookies Policy</a>
+                        &copy; {(new Date()).getFullYear()} Ocelot Consulting, Part of Accenture. All rights reserved. | <a href="https://www.accenture.com/us-en/about/privacy-policy" className="hover:text-accent" target="_blank" title="Privacy Policy">Privacy Policy</a> | <a href="https://www.accenture.com/us-en/support/company-cookies-similar-technology" className="hover:text-accent" target="_blank" title="Privacy Policy">Cookies Policy</a> | <a onClick={() => { (window as any).OneTrust?.ToggleInfoDisplay(); }} id="ot-sdk-btn" className="cursor-pointer hover:text-accent" title="Cookies Settings">Cookies Settings</a>
                     </div>
                 </div>
             </div>

--- a/src/components/OneTrustScript.tsx
+++ b/src/components/OneTrustScript.tsx
@@ -3,7 +3,7 @@ import Script from 'next/script'
 export default function OneTrustScript() {
     return (
         <>
-            <Script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" strategy='beforeInteractive' type="text/javascript" charSet="UTF-8" data-domain-script="3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef-test"></Script>
+            <Script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" strategy='beforeInteractive' type="text/javascript" charSet="UTF-8" data-domain-script={process.env.NEXT_PUBLIC_ONE_TRUST_DOMAIN_SCRIPT ?? ''}></Script>
             <Script type="text/javascript" strategy='beforeInteractive'>
                 {`function OptanonWrapper() { }`}
             </Script>

--- a/src/components/OneTrustScript.tsx
+++ b/src/components/OneTrustScript.tsx
@@ -1,0 +1,12 @@
+import Script from 'next/script'
+
+export default function OneTrustScript() {
+    return (
+        <>
+            <Script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" strategy='beforeInteractive' type="text/javascript" charSet="UTF-8" data-domain-script="3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef"></Script>
+            <Script type="text/javascript" strategy='beforeInteractive'>
+                {`function OptanonWrapper() { }`}
+            </Script>
+        </>
+    )
+}

--- a/src/components/OneTrustScript.tsx
+++ b/src/components/OneTrustScript.tsx
@@ -3,7 +3,7 @@ import Script from 'next/script'
 export default function OneTrustScript() {
     return (
         <>
-            <Script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" strategy='beforeInteractive' type="text/javascript" charSet="UTF-8" data-domain-script="3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef"></Script>
+            <Script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" strategy='beforeInteractive' type="text/javascript" charSet="UTF-8" data-domain-script="3a6bb61d-8924-4c57-a2b6-bd2306a9c5ef-test"></Script>
             <Script type="text/javascript" strategy='beforeInteractive'>
                 {`function OptanonWrapper() { }`}
             </Script>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import type { AppProps } from 'next/app'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import OneTrustScript from '@/components/OneTrustScript'
 import ContactDrawer from '@/components/ContactDrawer'
 import MenuDrawer from '@/components/MenuDrawer'
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
@@ -67,6 +68,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 <meta property="og:image:type" content="image/svg+xml" />
                 <meta name="twitter:image" content={`${origin}/assets/ocelot.svg`} />
             </Head>
+            <OneTrustScript />
             <Header setShowMenu={setShowMenu} setShowContact={setShowContact} />
             <main>
                 <Component {...pageProps} setShowContact={setShowContact} />


### PR DESCRIPTION
Adds OneTrust scripts to the `<head>` element and a link in the footer to re-open the cookies settings.

![image](https://github.com/ocelotconsulting/ocelotconsulting.github.io/assets/5490719/354bff99-57a1-4110-9d74-f9a08bf5df3c)
